### PR TITLE
Generalize espeak existance condition

### DIFF
--- a/speake3.py
+++ b/speake3.py
@@ -54,7 +54,8 @@ class Speake:
         self.status_output = ''
         self.status_error = ''
         # Condition to check if espeak-tts-engine is installed
-        if not os.path.exists('/usr/bin/espeak'):
+        espeak_exists = subprocess.run(['which', 'espeak'], stdout=subprocess.PIPE).stdout.decode('utf-8') != ''
+        if not espeak_exists:
             raise OSError("Espeak text-to-speech engine is not installed in this system!")
 
     def __listoutput(self, voices):


### PR DESCRIPTION
The espeak installation path could also be different than `/usr/bin/espeak`, for instance, on macOS, the homebrew package manager, installs it on `/usr/local/bin/espeak`. Therefore, the existance condition, can be generalized, by checking the output of `which espeak`. If it returns anything different than the empty string, then espeak is installed somewhere, else it is not.